### PR TITLE
Proposed bugfix - annotating stage of worm in first image breaks if last image's stage is not annotated

### DIFF
--- a/elegant/gui/stage_field.py
+++ b/elegant/gui/stage_field.py
@@ -56,13 +56,14 @@ class StageField(annotator.AnnotationField):
         fb_i = self.flipbook.pages.index(self.page)
         youngest_stage_i = self.stage_indices[stage] - 1
         # we can never manually set the first stage, so youngest_stage_i is always >= 0
-        for page in self.flipbook.pages[fb_i-1::-1]:
-            page_stage = self.get_annotation(page)
-            page_stage_i = self.stage_indices.get(page_stage, len(self.stages)) # will be > all others if stage is None
-            if page_stage_i < youngest_stage_i:
-                youngest_stage_i = page_stage_i
-            else:
-                page.annotations[self.name] = self.stages[youngest_stage_i]
+        if fb_i > 0:    # Exclude update of previous pages if this is the first image
+            for page in self.flipbook.pages[fb_i-1::-1]:
+                page_stage = self.get_annotation(page)
+                page_stage_i = self.stage_indices.get(page_stage, len(self.stages)) # will be > all others if stage is None
+                if page_stage_i < youngest_stage_i:
+                    youngest_stage_i = page_stage_i
+                else:
+                    page.annotations[self.name] = self.stages[youngest_stage_i]
 
         # pages after this will be brought into compliance by update_widget
         self.update_widget(stage)


### PR DESCRIPTION
Combined bugfix and bug report

Replicating bug - 
1. Initialize annotator
from ris_widget.ris_widget import RisWidget; rw = RisWidget(); rw.show()
from elegant.gui import stage_field, experiment_annotator
from elegant import load_data
import pathlib
expt_dir = '/mnt/9karray/Sinha_Drew/20180518_spe-9_Run_3/'
expt_pos = load_data.scan_experiment_dir(expt_dir)
sf = stage_field.StageField(transitions=['Hatch','First Egg Laid','Death'],shortcuts=['h','v','d'])
ea = experiment_annotator.ExperimentAnnotator(rw,pathlib.Path(expt_dir).parts[-1],expt_pos,[sf])

2. Attempt to stage first image in the stack (i.e. stage it larvae with by pressing 'h')

Expected behavior - 'stage' annotation of first/future pages should be larva
Actual behavior - 'stage' annotation for all pages remains 'egg' (though the label in the stage field widget remains 'larva', going to next page and then coming back reverts the label to 'egg')
Affects commit a2788e6c68a5091defb3f667fa381c4126781645

Aberrant behavior: In the current commit, code that resets previous flipbook pages to youngest page stage in stage_field.StageField.set_stage (59-65) iterates backwards from the last image (idx -1) and incorrectly assigns the youngest stage as the first stage (i.e. 'egg')


