### PR TITLE
Added checkbox to mark good position

### DIFF
--- a/elegant/gui/experiment_annotator.py
+++ b/elegant/gui/experiment_annotator.py
@@ -82,6 +82,8 @@ class ExperimentAnnotator:
         self._add_button(nav_buttons, '\N{DOWNWARDS ARROW}', self.next_timepoint)
         self._next_button = self._add_button(nav_buttons, '\N{RIGHTWARDS ARROW TO BAR}', self.next_position)
         layout.addLayout(nav_buttons)
+        self.goodpos_indicator = Qt.QCheckBox(text='Is Good Position?')
+        layout.addWidget(self.goodpos_indicator)
         self.notes = Qt.QPlainTextEdit()
         self.notes.setPlaceholderText('notes')
         layout.addWidget(self.notes)
@@ -184,6 +186,7 @@ class ExperimentAnnotator:
         except FileNotFoundError:
             self.position_annotations = {}
             self.timepoint_annotations = {}
+        self.goodpos_indicator.setChecked(self.position_annotations.get('is_good', True)) # Set to be good by default
         self.notes.setPlainText(self.position_annotations.get('notes', ''))
         unknown_timepoints = []
         for timepoint_name, annotations in self.timepoint_annotations.items():
@@ -204,6 +207,7 @@ class ExperimentAnnotator:
             self.timepoint_annotations[page._timepoint_name] = getattr(page, 'annotations', {})
         self.position_annotations['notes'] = self.notes.toPlainText()
         current_timepoint_name = list(self.timepoints.keys())[self.ris_widget.flipbook.current_page_idx]
+        self.position_annotations['is_good'] = self.goodpos_indicator.isChecked()
         self.position_annotations['__last_timepoint_annotated__'] = current_timepoint_name
         load_data.write_annotation_file(self.annotation_file, self.position_annotations, self.timepoint_annotations)
 


### PR DESCRIPTION
Some of us in the lab discussed having a dedicated annotation for whether a position is "good" so that we can skip those positions during acquisition or downstream analysis. This branch adds this functionality as a checkbox in the experiment annotator; the checked state of the box is stored under the key 'is_good' in the global annotations of the current position.