### PR TITLE
Bugfix for None adjacent timepoints

### DIFF
--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -344,10 +344,11 @@ class PoseMeasurements:
             centroid_distances = []
             rmsds = []
             for adjacent in (before, after):
-                adj_center_tck, adj_width_tck = adjacent.get(self.pose_annotation, (None, None))
-                if adj_center_tck is not None:
-                    centroid_distances.append(spline_geometry.centroid_distance(center_tck, adj_center_tck, num_points=300))
-                    rmsds.append(spline_geometry.rmsd(center_tck, adj_center_tck, num_points=300))
+                if adjacent is not None:
+                    adj_center_tck, adj_width_tck = adjacent.get(self.pose_annotation, (None, None))
+                    if adj_center_tck is not None:
+                        centroid_distances.append(spline_geometry.centroid_distance(center_tck, adj_center_tck, num_points=300))
+                        rmsds.append(spline_geometry.rmsd(center_tck, adj_center_tck, num_points=300))
             if len(rmsds) > 0:
                 measures['centroid_dist'] = numpy.mean(centroid_distances) * self.microns_per_pixel
                 measures['rms_dist'] = numpy.mean(rmsds) * self.microns_per_pixel


### PR DESCRIPTION
Fixed issue with PoseMeasurements.measure when at least one adjacent timepoint is None.

Running process_data.measure with a PoseMeasurements instance in the measures yields a 'AttributeError: 'NoneType' object has no attribute 'get'' error (process_data.PoseMeasurements.measure:347). This error occurs for the edge cases of the first and last timepoints where before/after are None per process_data.measure:229-230. The bugfix is a conditional to test for the None, and skipping in the affirmative. For these two edge cases, this fix yields a one-sided estimate of movement rate. 