### PR TITLE
Bugfix for scan_experiment_directory removing positions w/o timepoint

### DIFF
--- a/elegant/load_data.py
+++ b/elegant/load_data.py
@@ -92,7 +92,7 @@ def scan_experiment_dir(experiment_root, channels='bf', timepoint_filter=None, i
             timepoints[timepoint_name] = channel_images
     for position_name, timepoints in list(positions.items()):
         if len(timepoints) == 0:
-            del positions
+            del positions['position_name']
     return positions
 
 def scan_positions(experiment_root, position_filter, channels='bf', image_ext='png'):


### PR DESCRIPTION
Recent update to load_data.scan_experiment_directory:95 attempts to prune positions not containing timepoints; however, the modification deletes the positions data structure (manifests as an 'UnboundLocalError' on subsequent iterations during looping through). This bugfix corrects that behavior. 