### PR TITLE
Add cleaning

### DIFF
--- a/elegant/clean_timepoint_data.py
+++ b/elegant/clean_timepoint_data.py
@@ -123,19 +123,21 @@ def remove_excluded_positions(experiment_root,dry_run=False):
     good_annotations = load_data.filter_annotations(annotations, load_data.filter_excluded)
     excluded_positions = sorted(set(annotations.keys()).difference(set(good_annotations.keys())))
 
+    excluded_root = experiment_root / 'excluded_positions'
+
     for position in excluded_positions:
         if (experiment_root / position).exists():
             print(f'Found an excluded position to delete {position}')
             if not dry_run:
-                (experiment_root / 'excluded_positions' / position).mkdir(parents=True,exist_ok=True)
-                (experiment_root / 'excluded_positions' / 'annotations').mkdir(parents=True,exist_ok=True)
+                (excluded_root / position).mkdir(parents=True,exist_ok=True)
+                (excluded_root / 'annotations').mkdir(parents=True,exist_ok=True)
 
-                shutil.copy(str(experiment_root / position / 'position_metadata.json'),
-                    str(experiment_root / 'excluded_positions' / position / 'position_metadata.json'))
-                shutil.copy(str(experiment_root / 'annotations' / f'{position}.pickle'),
-                    str(experiment_root / 'excluded_positions' / 'annotations' / f'{position}.pickle'))
-                shutil.copy(str(experiment_root /  'experiment_metadata.json'),
-                    str(experiment_root / 'excluded_positions' / 'experiment_metadata_old.json')) # Back this up JIC....
+                shutil.copy(experiment_root / position / 'position_metadata.json',
+                    excluded_root / position / 'position_metadata.json')
+                shutil.copy(experiment_root / 'annotations' / f'{position}.pickle',
+                    excluded_root / 'annotations' / f'{position}.pickle')
+                shutil.copy(experiment_root /  'experiment_metadata.json',
+                    excluded_root / 'experiment_metadata.json') # Back this up JIC....
 
                 shutil.rmtree(str(experiment_root / position))
                 (experiment_root / 'annotations' / f'{position}.pickle').unlink()

--- a/elegant/clean_timepoint_data.py
+++ b/elegant/clean_timepoint_data.py
@@ -110,7 +110,7 @@ def remove_excluded_positions(experiment_root,dry_run=False):
     Each position has a folder containing a copy of its position_metadata;
     an 'annotations' subfolder contains all of the annotations for excluded positions;
     and, a copy of the old experiment_metadata lies in this subfolder
-    (though subsequent calls to remove_excluded_positions will overwrite this copy of the experiment metadata
+    (though subsequent calls to remove_excluded_positions will overwrite this copy of the experiment metadata).
     Thus, it is recommended that this function be run on completed experiments to prevent data loss.
 
     Parameters:

--- a/elegant/clean_timepoint_data.py
+++ b/elegant/clean_timepoint_data.py
@@ -106,8 +106,12 @@ def remove_excluded_positions(experiment_root,dry_run=False):
 
     This function deletes position folders from the specified experiment directory,
     but saves position_metadata and annotations into the 'excluded_positions' subfolder.
-    The 'excluded_positions' subfolder has parallel structure to the standard experiment_root,
-    with one 'annotations' folder for annotations and each position having its own folder containing metadata.
+    'excluded_positions' has a parallel structure to the standard experiment root
+    Each position has a folder containing a copy of its position_metadata;
+    an 'annotations' subfolder contains all of the annotations for excluded positions;
+    and, a copy of the old experiment_metadata lies in this subfolder
+    (though subsequent calls to remove_excluded_positions will overwrite this copy of the experiment metadata
+    Thus, it is recommended that this function be run on completed experiments to prevent data loss.
 
     Parameters:
         experiment_root: str/pathlib.Path to experiment

--- a/elegant/clean_timepoint_data.py
+++ b/elegant/clean_timepoint_data.py
@@ -139,7 +139,7 @@ def remove_excluded_positions(experiment_root,dry_run=False):
                 shutil.copy(experiment_root /  'experiment_metadata.json',
                     excluded_root / 'experiment_metadata.json') # Back this up JIC....
 
-                shutil.rmtree(str(experiment_root / position))
+                shutil.rmtree(experiment_root / position)
                 (experiment_root / 'annotations' / f'{position}.pickle').unlink()
 
                 # Load/save atomically for each position to minimize the chance of failing oneself into a bad state

--- a/elegant/clean_timepoint_data.py
+++ b/elegant/clean_timepoint_data.py
@@ -28,11 +28,18 @@ def remove_timepoint_for_position(experiment_root, position, timepoint, dry_run=
 
     experiment_root = pathlib.Path(experiment_root)
 
-    files_to_remove = [img_file for img_file in (experiment_root / position).iterdir() if img_file.name.startswith(timepoint)]
-    if len(files_to_remove) > 0:
-        print(f'Found files for removal for position {position}: {files_to_remove}')
+    image_files_to_remove = [img_file for img_file in (experiment_root / position).iterdir() if img_file.name.startswith(timepoint)]
+    if len(image_files_to_remove) > 0:
+        print(f'Found image files for removal for position {position}: {image_files_to_remove}')
         if not dry_run:
-            [img_file.unlink() for img_file in files_to_remove]
+            [img_file.unlink() for img_file in image_files_to_remove]
+
+    if (experiment_root / 'derived_data' / 'mask' / position).exists():
+        mask_files_to_remove = [mask_file for mask_file in (experiment_root / 'derived_data' / 'mask' / position).iterdir() if mask_file.name.startswith(timepoint)]
+        if len(mask_files_to_remove) > 0:
+            print(f'Found mask files for removal for position {position}: {mask_files_to_remove}')
+            if not dry_run:
+                [mask_file.unlink() for mask_file in mask_files_to_remove]
 
     md_file = (experiment_root / position /'position_metadata.json')
     with md_file.open() as md_fp:


### PR DESCRIPTION
In this push, remove_excluded_positions builds a "excluded_positions" subfolder with parallel structure to standard experiment folders. The docstring has some extensive elaboration on this.