### PR TITLE
Bugfix for remove_position_from_experiment

### DIFF
--- a/elegant/clean_timepoint_data.py
+++ b/elegant/clean_timepoint_data.py
@@ -85,7 +85,7 @@ def remove_timepoint_from_experiment(experiment_root, timepoint, dry_run=False):
     """
 
     experiment_root = pathlib.Path(experiment_root)
-    positions = [metadata_file.parent for metadata_file in sorted(experiment_root.glob('*/position_metadata.json'))]
+    positions = [metadata_file.parent.name for metadata_file in sorted(experiment_root.glob('*/position_metadata.json'))]
 
     for position in positions:
         remove_timepoint_for_position(experiment_root, position, timepoint, dry_run=dry_run)


### PR DESCRIPTION
Ok, last one - I swear; this one's pretty subtle. This bugfix addresses an error where remove_timepoint_from_experiment inadvertantly passes absolute paths to positions rather than the position name/string to remove_timepoint_from_position. This results in not being able to find the annotation file based on the pathlib concatenation (iterating through the directory succeeds due to the passed position path being taken as the anchor during path concatenation). 