### PR TITLE
Proposed fix + cleaned doc; yields the minimal set of measurements specified in the previous version

### DIFF
--- a/elegant/measure_fluor.py
+++ b/elegant/measure_fluor.py
@@ -45,13 +45,10 @@ def subregion_measures(image, mask):
         data:
             [sum, mean, median, percentile_95, percentile_99,
             expression_sum, expression_mean, expression_median,
-            expression_percentile_95, expression_percentile_99,
             expression_area_fraction,
             high_expression_sum, high_expression_mean, high_expression_median,
-            high_expression_percentile_95, high_expression_percentile_99,
             high_expression_area_fraction,
-            over_99_sum, over_99_mean, over_99_median,
-            over_99_percentile_95, over_99_percentile_99]
+            over_99_sum, over_99_mean, over_99_median]
             where the 'area_fraction' measurements represent the fraction of the
             mask area encompassed by the expression and high_expression areas.
         region_masks: [expression_mask, high_expression_mask, over_99_mask]
@@ -72,7 +69,7 @@ def subregion_measures(image, mask):
     high_expression_measures.append(high_expression_area_fraction)
     percentile_99 = mask_measures[-1]
     over_99_mask = (image > percentile_99) & mask
-    over_99_measures = region_measures(image, expression_mask)
+    over_99_measures = region_measures(image, expression_mask)[:3]
     data = mask_measures + expression_measures + high_expression_measures + over_99_measures
     region_masks = [expression_mask, high_expression_mask, over_99_mask]
     return data, region_masks


### PR DESCRIPTION
This is a combined bug report + fix. Running process_data.measure_worms with a process_data.FluorMeasurements instance in measures yields an assertion error: 

(process_data)
--> 257                     assert len(features) == len(measure.feature_names)

The number of returned features doesn't equal the prescribed feature names: 

ipdb> len(measure.feature_names)
16
ipdb> len(features)
18

This fix prunes the docstring + measures to the amount of features that was specified by the previous analysis code. Feel free to add back whichever features seem like they make the most sense.