### PR TITLE
Bugfix for meauring timepoints with empty mask

### DIFF
--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -441,6 +441,10 @@ class FluorMeasurements:
             # even if the file is cached in RAM. Strange but true.
             mask = worm_spline.lab_frame_mask(center_tck, width_tck, image.shape)
 
+        if mask.sum() == 0:
+            print(f'Mask for {position_root.name} at {timepoint} had no worm region defined.')
+            return [numpy.nan] * len(self.feature_names)
+
         mask = mask > 0
         image = image.astype(numpy.float32) * flatfield
         data, region_masks = measure_fluor.subregion_measures(image, mask)


### PR DESCRIPTION
Previously, making fluorescent measurements for a timepoint during which an animal has an empty mask/pose causes an error in measure_fluor.region_features:23 not allowing calculation on an empty numpy array. This bugfix prevents FluorMeasurements from passing an image+empty mask to measure_fluor.subregion_features. This fix is yields the minimal error handling for the basic elegant pipeline, but, in the future, measure_fluor should probably have its own error checking to handle empty masks.