### PR TITLE
Fix segmentation

### DIFF
--- a/elegant/segment_images.py
+++ b/elegant/segment_images.py
@@ -7,7 +7,7 @@ import tempfile
 
 import freeimage
 
-from . import process_data
+from . import process_data, load_data
 
 MATLAB_RUNTIME = '/usr/local/MATLAB/MATLAB_Runtime/v94'
 SEGMENT_EXECUTABLE = 'processImageBatch'

--- a/elegant/segment_images.py
+++ b/elegant/segment_images.py
@@ -38,8 +38,9 @@ def segment_images(images_and_outputs, model, use_gpu=True):
             temp.write(str(image_file)+'\n')
             temp.write(str(mask_file)+'\n')
         temp.flush()
-        process = subprocess.run([segmenter, temp.name, str(int(bool(use_gpu))), model],
-            capture_output=True, text=True, env=env)
+        # process = subprocess.run([segmenter, temp.name, str(int(bool(use_gpu))), model],
+        #     capture_output=True, text=True, env=env)
+        process = subprocess.run([segmenter, temp.name, str(int(bool(use_gpu))), model], env=env) # quick hack for python 3.6 since capture_output and text not on python3.6
     return process
 
 def segment_positions(positions, model, use_gpu=True, overwrite_existing=False):

--- a/elegant/segment_images.py
+++ b/elegant/segment_images.py
@@ -70,6 +70,6 @@ def segment_positions(positions, model, use_gpu=True, overwrite_existing=False):
         if overwrite_existing or not mask_path.exists():
             mask_path.parent.mkdir(exist_ok=True, parents=True)
             images_and_outputs.append((image_path, mask_path))
-    process = segment_images.segment_images(images_and_outputs, model, use_gpu)
+    process = segment_images(images_and_outputs, model, use_gpu)
     process_data.annotate(experiment_root, [process_data.annotate_poses])
     return process


### PR DESCRIPTION
This pull fixes the obvious bugs in the new elegant-based segment_experiment workflow (i.e. segmenting a whole experiment from the calling process_experiment.segment_experiment). Note that I had to hack the subprocess call in segment_images; the call uses kwargs that were introduced with python 3.7 (scopes are on 3.6). Feel free to revert this hack or keep it around until we do the next software upgrade for the scopes.

Side note: worm_segmenter is now data-only (+executable) as suggested. Everything has been updated and tested on purple. 