### PR TITLE
Add lawn measurements

### DIFF
--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -547,35 +547,3 @@ class MaskFluorMeasurements(_FluorMeasureBase):
             return None
         else:
             return freeimage.read(mask_file)
-
-class LawnMeasurements:
-    feature_names = ['summed_lawn_intensity', 'median_lawn_intensity', 'background_intensity']
-
-    def measure(self, position_root, timepoint, annotations, before, after):
-        measures = {}
-
-        # Load metadata.... TODO ask Zach if this can be a feature of the measurement signature
-        experiment_root, position_name = position_root.parent, position_root.name
-        with (experiment_root / 'experiment_metadata.json').open('r') as md_file:
-            metadata = json.load(md_file)
-
-        timepoint_imagepath = position_root / (timepoint + ' bf.png')
-        timepoint_image = freeimage.read(timepoint_imagepath)
-        rescaled_image = process_images.pin_image_mode(timepoint_image, optocoupler=metadata['optocoupler'])
-
-        lawn_mask = freeimage.read(experiment_root / 'derived_data' / 'lawn_masks' / f'{position_name}.png').astype('bool')
-        vignette_mask = process_images.vignette_mask(metadata['optocoupler'], timepoint_image.shape)
-
-        # Remove the animal from the lawn if possible.
-        center_tck, width_tck = annotations.get('pose', (None, None))
-        if center_tck is None:
-            animal_mask = numpy.zeros(timepoint_image.shape).astype('bool')   # Or should this just return Nones in the measures???
-        else:
-            animal_mask = worm_spline.lab_frame_mask(center_tck, width_tck, timepoint_image.shape).astype('bool')
-        lawn_mask = lawn_mask & ~animal_mask
-
-        measures['summed_lawn_intensity'] = numpy.sum(rescaled_image[lawn_mask])
-        measures['median_lawn_intensity'] = numpy.median(rescaled_image[lawn_mask])
-        measures['background_intensity'] = numpy.median(rescaled_image[~lawn_mask & vignette_mask])
-
-        return [measures[feature_name] for feature_name in self.feature_names]

--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -80,6 +80,93 @@ def annotate_stage_pos(experiment_root, position, metadata, annotations):
     annotations['stage_y'] = y
     annotations['starting_stage_z'] = z
 
+def annotate_lawn(experiment_root, position, metadata, annotations):
+    '''Position annotator used to find the lawn and associated metadata about it'''
+    num_images_for_lawn = 3
+
+    print(f'Working on position {position}')
+    position_root = experiment_root / position
+    lawn_mask_root = experiment_root / 'derived_data' / 'lawn_masks'
+    lawn_mask_root.mkdir(parents=True, exist_ok=True)
+
+    lawn_model_root = experiment_root / 'derived_data' / 'lawn_models'
+    lawn_model_root.mkdir(parents=True, exist_ok=True)
+
+    microns_per_pixel = process_images.microns_per_pixel(metadata['objective'],metadata['optocoupler'])
+
+    position_images = load_data.scan_experiment_dir(experiment_root)[position]
+    first_imagepaths = []
+    for timepoint, timepoint_images in position_images.items():
+        if position_root / (timepoint + ' bf.png') in timepoint_images:
+            first_imagepaths.append(str(position_root / (timepoint + ' bf.png')))
+        if len(first_imagepaths) == num_images_for_lawn:
+            break
+
+    first_images = list(map(freeimage.read, first_imagepaths))
+    first_images = [process_images.pin_image_mode(image, optocoupler=metadata['optocoupler'])
+        for image in first_images]
+    median_first_images = numpy.median(first_images, axis=0)
+
+    individual_lawns = [gmm_lawn_maker(image, metadata['optocoupler']) for image in first_images]
+    lawn_mask = numpy.max(individual_lawns, axis=0)
+
+    median_lm, gmm_model = gmm_lawn_maker(median_first_images.astype('int'), metadata['optocoupler'], return_model=True)
+
+    vignette_mask = process_images.vignette_mask(metadata['optocoupler'], lawn_mask.shape)
+
+    with (lawn_model_root / f'{position}.pickle').open('wb') as lm_file:
+        gmm_means = gmm_model.means_.flatten()
+        gmm_stds = numpy.sqrt(gmm_model.covariances_.flatten())
+        sorting_idxs = gmm_means.argsort()
+        gmm_means, gmm_stds = gmm_means[sorting_idxs], gmm_stds[sorting_idxs] # First one is lawn (since less intensity is darker)
+
+        model_features = {'lawn_mean':gmm_means[0], 'background_mean':gmm_means[1],
+            'lawn_std': gmm_stds[0], 'background_std': gmm_stds[1]}
+        pickle.dump(model_features, lm_file)
+    freeimage.write(lawn_mask.astype('uint8')*255, str(lawn_mask_root / f'{position}.png')) # Some better way to store this mask in the annotations?
+    annotations['lawn_area'] = lawn_mask.sum() * microns_per_pixel**2
+
+def gmm_lawn_maker(image, optocoupler, return_model=False):
+    '''Find a lawn in an image use Gaussian mixture modeling (GMM)
+
+    This lawn maker models an image (i.e. its pixel intensities) as as mixture
+        of two Gaussian densities. Each corresponds to either the background & lawn.
+
+    Parameters:
+        image - numpy ndarray of the image to find the lawn from
+        optocoupler - optocoupler magnification (as a float) used for the specified image
+
+    Returns:
+        lawn mask as a bool ndarray
+        fitted GMM model
+    '''
+    scaled_image = ndi_filters.median_filter(image, size=(3,3), mode='constant')
+    vignette_mask = process_images.vignette_mask(optocoupler, image.shape)
+
+    img_data = scaled_image[vignette_mask]
+    img_hist = numpy.bincount(img_data.flatten())
+    img_hist = img_hist/img_hist.sum()
+
+    gmm = mixture.GaussianMixture(n_components=2)
+    gmm.fit(numpy.expand_dims(img_data,1))
+
+    # Calculate boundary point for label classification as intensity threshold
+    gmm_support = numpy.linspace(0,2**16-1,2**16)
+
+    labels = gmm.predict(numpy.reshape(gmm_support, (-1,1)))
+    thr = numpy.argmax(numpy.abs(numpy.diff(labels)))
+    lawn_mask = (scaled_image < thr) & vignette_mask
+
+    lawn_mask = morphology.binary_erosion(lawn_mask, iterations=10)
+    lawn_mask = zpl_mask.get_largest_object(lawn_mask)
+    lawn_mask = morphology.binary_fill_holes(lawn_mask)
+    lawn_mask = morphology.binary_dilation(lawn_mask, iterations=10)
+
+    if return_model:
+        return lawn_mask, gmm
+    else:
+        return lawn_mask
+
 def set_hatch_time(experiment_root, year, month, day, hour):
     """Manually set a hatch-time for all worms in an experiment.
 
@@ -478,3 +565,35 @@ class MaskFluorMeasurements(_FluorMeasureBase):
             return None
         else:
             return freeimage.read(mask_file)
+
+class LawnMeasurements:
+    feature_names = ['summed_lawn_intensity', 'median_lawn_intensity', 'background_intensity']
+
+    def measure(self, position_root, timepoint, annotations, before, after):
+        measures = {}
+
+        # Load metadata.... TODO ask Zach if this can be a feature of the measurement signature
+        experiment_root, position_name = position_root.parent, position_root.name
+        with (experiment_root / 'experiment_metadata.json').open('r') as md_file:
+            metadata = json.load(md_file)
+
+        timepoint_imagepath = position_root / (timepoint + ' bf.png')
+        timepoint_image = freeimage.read(timepoint_imagepath)
+        rescaled_image = process_images.pin_image_mode(timepoint_image, optocoupler=metadata['optocoupler'])
+
+        lawn_mask = freeimage.read(experiment_root / 'derived_data' / 'lawn_masks' / f'{position_name}.png').astype('bool')
+        vignette_mask = process_images.vignette_mask(metadata['optocoupler'], timepoint_image.shape)
+
+        # Remove the animal from the lawn if possible.
+        center_tck, width_tck = annotations.get('pose', (None, None))
+        if center_tck is None:
+            animal_mask = numpy.zeros(timepoint_image.shape).astype('bool')   # Or should this just return Nones in the measures???
+        else:
+            animal_mask = worm_spline.lab_frame_mask(center_tck, width_tck, timepoint_image.shape).astype('bool')
+        lawn_mask = lawn_mask & ~animal_mask
+
+        measures['summed_lawn_intensity'] = numpy.sum(rescaled_image[lawn_mask])
+        measures['median_lawn_intensity'] = numpy.median(rescaled_image[lawn_mask])
+        measures['background_intensity'] = numpy.median(rescaled_image[~lawn_mask & vignette_mask])
+
+        return [measures[feature_name] for feature_name in self.feature_names]

--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -108,8 +108,7 @@ def annotate_lawn(experiment_root, position, metadata, annotations, num_images_f
         for image in first_images]
 
     individual_lawns = [gmm_lawn_maker(image, metadata['optocoupler']) for image in first_images]
-    lawn_mask = numpy.max(individual_lawns, axis=0)
-    vignette_mask = process_images.vignette_mask(metadata['optocoupler'], lawn_mask.shape)
+    lawn_mask = numpy.bitwise_or.reduce(individual_lawns, axis=0)
 
     freeimage.write(lawn_mask.astype('uint8')*255, str(lawn_mask_root / f'{position}.png')) # Some better way to store this mask in the annotations?
     annotations['lawn_area'] = lawn_mask.sum() * microns_per_pixel**2

--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -98,7 +98,7 @@ def annotate_lawn(experiment_root, position, metadata, annotations, num_images_f
     first_images = [process_images.pin_image_mode(image, optocoupler=metadata['optocoupler'])
         for image in first_images]
 
-    individual_lawns = [segment_images.gmm_lawn_maker(image, metadata['optocoupler']) for image in first_images]
+    individual_lawns = [segment_images.find_lawn(image, metadata['optocoupler']) for image in first_images]
     lawn_mask = numpy.bitwise_or.reduce(individual_lawns, axis=0)
 
     freeimage.write(lawn_mask.astype('uint8')*255, str(lawn_mask_root / f'{position}.png'))

--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -85,9 +85,8 @@ def annotate_stage_pos(experiment_root, position, metadata, annotations):
     annotations['stage_y'] = y
     annotations['starting_stage_z'] = z
 
-def annotate_lawn(experiment_root, position, metadata, annotations):
+def annotate_lawn(experiment_root, position, metadata, annotations, num_images_for_lawn=3):
     '''Position annotator used to find the lawn and associated metadata about it'''
-    num_images_for_lawn = 3
 
     print(f'Working on position {position}')
     position_root = experiment_root / position
@@ -107,13 +106,9 @@ def annotate_lawn(experiment_root, position, metadata, annotations):
     first_images = list(map(freeimage.read, first_imagepaths))
     first_images = [process_images.pin_image_mode(image, optocoupler=metadata['optocoupler'])
         for image in first_images]
-    median_first_images = numpy.median(first_images, axis=0)
 
     individual_lawns = [gmm_lawn_maker(image, metadata['optocoupler']) for image in first_images]
     lawn_mask = numpy.max(individual_lawns, axis=0)
-
-    median_lm, gmm_model = gmm_lawn_maker(median_first_images.astype('int'), metadata['optocoupler'], return_model=True)
-
     vignette_mask = process_images.vignette_mask(metadata['optocoupler'], lawn_mask.shape)
 
     freeimage.write(lawn_mask.astype('uint8')*255, str(lawn_mask_root / f'{position}.png')) # Some better way to store this mask in the annotations?

--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -7,15 +7,21 @@ import json
 import numpy
 import collections
 import datetime
+import pickle
+
+from scipy.ndimage import filters
+from skimage import mixture
 
 from zplib.curve import spline_geometry
 from zplib.curve import interpolate
+import zplib.image.mask as zpl_mask
 import freeimage
 
 from . import worm_data
 from . import load_data
 from . import worm_spline
 from . import measure_fluor
+from . import process_images
 
 DERIVED_ROOT = 'derived_data'
 
@@ -140,7 +146,7 @@ def gmm_lawn_maker(image, optocoupler, return_model=False):
         lawn mask as a bool ndarray
         fitted GMM model
     '''
-    scaled_image = ndi_filters.median_filter(image, size=(3,3), mode='constant')
+    scaled_image = filters.median_filter(image, size=(3,3), mode='constant')
     vignette_mask = process_images.vignette_mask(optocoupler, image.shape)
 
     img_data = scaled_image[vignette_mask]

--- a/elegant/segment_images.py
+++ b/elegant/segment_images.py
@@ -177,6 +177,7 @@ def find_lawn(image, optocoupler, return_model=False):
     thr = numpy.argmax(numpy.abs(numpy.diff(labels)))
     lawn_mask = (filtered_image < thr) & vignette_mask
 
+    # Do some smoothing of the lawn by eroding, then grabbing the largest object afterwards.
     lawn_mask = ndimage.morphology.binary_erosion(lawn_mask, iterations=10)
     lawn_mask = zpl_mask.get_largest_object(lawn_mask)
     lawn_mask = ndimage.morphology.binary_fill_holes(lawn_mask)

--- a/elegant/segment_images.py
+++ b/elegant/segment_images.py
@@ -7,8 +7,7 @@ import pkg_resources
 import subprocess
 import tempfile
 
-from scipy.ndimage import filters
-from scipy.ndimage import morphology
+from scipy import ndimage
 from skimage import mixture
 
 
@@ -147,7 +146,7 @@ def annotate_poses_from_masks(positions, mask_root, annotations, overwrite_exist
                 current_annotation[annotation] = pose
             current_annotation[original_annotation] = pose
 
-def gmm_lawn_maker(image, optocoupler, return_model=False):
+def find_lawn(image, optocoupler, return_model=False):
     '''Find a lawn in an image use Gaussian mixture modeling (GMM)
 
     This lawn maker models an image (i.e. its pixel intensities) as as mixture
@@ -161,7 +160,7 @@ def gmm_lawn_maker(image, optocoupler, return_model=False):
         lawn mask as a bool ndarray
         fitted GMM model
     '''
-    filtered_image = filters.median_filter(image, size=(3,3), mode='constant')
+    filtered_image = ndimage.filters.median_filter(image, size=(3,3), mode='constant')
     vignette_mask = process_images.vignette_mask(optocoupler, image.shape)
 
     img_data = filtered_image[vignette_mask]
@@ -178,10 +177,10 @@ def gmm_lawn_maker(image, optocoupler, return_model=False):
     thr = numpy.argmax(numpy.abs(numpy.diff(labels)))
     lawn_mask = (filtered_image < thr) & vignette_mask
 
-    lawn_mask = morphology.binary_erosion(lawn_mask, iterations=10)
+    lawn_mask = ndimage.morphology.binary_erosion(lawn_mask, iterations=10)
     lawn_mask = zpl_mask.get_largest_object(lawn_mask)
-    lawn_mask = morphology.binary_fill_holes(lawn_mask)
-    lawn_mask = morphology.binary_dilation(lawn_mask, iterations=10)
+    lawn_mask = ndimage.morphology.binary_fill_holes(lawn_mask)
+    lawn_mask = ndimage.morphology.binary_dilation(lawn_mask, iterations=10)
 
     if return_model:
         return lawn_mask, gmm


### PR DESCRIPTION
This pull request provides automated lawn finding with sklearn's Gaussian mixture modeling (GMM). At the core, a 2-component GMM is fit to image histogram of a single image and a threshold for lawn_segmentation is computed as the classification boundary between the two Gaussians. An annotator (annotate_lawn) constructs a lawn by combining the lawns found from several of the first images in a position timecourse (as a bitwise or) and saves the lawn to disk (+ adds the lawn area to the position annotations).  A measurement class also makes measurements of background and lawn intensities using the automatically generated mask.

There are a couple of things that could use feedback (also commented below....):

1. Is it worth it to add the experiment_metadata (or general position annotations) to measurement class signature? Here, I load it for the optocoupler & vignette mask. In the workflow of using the metadata more (+ the automated vignette masks from process_images in this instance), it seems like it might make sense.

2. Is there a well-constrained way to include lawn mask data in the position annotations? Right now, one of the two major bottlenecks is measurement of lawn parameters. Naively, I can only imagine that this is due to reading from disk. This happens twice in the measurements - once for the image (can't help that), and again for the position's lawn mask. 