### PR TITLE
Allow user to specify custom annotation subdirectory/root for creating/modifying annotations

### DIFF
--- a/elegant/gui/experiment_annotator.py
+++ b/elegant/gui/experiment_annotator.py
@@ -11,7 +11,7 @@ from ris_widget.overlay import base
 from .. import load_data
 
 class ExperimentAnnotator:
-    def __init__(self, ris_widget, experiment_name, positions, annotation_fields, start_position=None, readonly=False):
+    def __init__(self, ris_widget, experiment_name, positions, annotation_fields, start_position=None, readonly=False, annotation_subdir='annotations'):
         """Set up a GUI for annotating an entire experiment.
 
         Annotations for each experiment position (i.e. each worm) are loaded
@@ -45,6 +45,7 @@ class ExperimentAnnotator:
         """
         self.ris_widget = ris_widget
         self.readonly = readonly
+        self.annotation_subdir = annotation_subdir
         ris_widget.add_annotator(annotation_fields)
         self.annotation_fields = annotation_fields
         self._init_positions(positions)
@@ -194,7 +195,7 @@ class ExperimentAnnotator:
 
     @property
     def annotation_file(self):
-        return self.experiment_root / 'annotations' / (self.position_name + '.pickle')
+        return self.experiment_root / self.annotation_subdir / (self.position_name + '.pickle')
 
     def load_annotations(self):
         try:

--- a/elegant/gui/experiment_annotator.py
+++ b/elegant/gui/experiment_annotator.py
@@ -11,7 +11,7 @@ from ris_widget.overlay import base
 from .. import load_data
 
 class ExperimentAnnotator:
-    def __init__(self, ris_widget, experiment_name, positions, annotation_fields, start_position=None, readonly=False, annotation_subdir='annotations'):
+    def __init__(self, ris_widget, experiment_name, positions, annotation_fields, start_position=None, readonly=False, annotation_dir='annotations'):
         """Set up a GUI for annotating an entire experiment.
 
         Annotations for each experiment position (i.e. each worm) are loaded
@@ -41,11 +41,13 @@ class ExperimentAnnotator:
             start_position: name of starting position to load first (e.g. "009").
                 if none specified, load the first position. To change to an
                 arbitrary position mid-stream, call the load_position() method.
+            annotation_dir: str/pathlib.Path to the subdirectory from where to 
+                load/save annotaions.
 
         """
         self.ris_widget = ris_widget
         self.readonly = readonly
-        self.annotation_subdir = annotation_subdir
+        self.annotation_dir = annotation_dir
         ris_widget.add_annotator(annotation_fields)
         self.annotation_fields = annotation_fields
         self._init_positions(positions)
@@ -195,7 +197,7 @@ class ExperimentAnnotator:
 
     @property
     def annotation_file(self):
-        return self.experiment_root / self.annotation_subdir / (self.position_name + '.pickle')
+        return self.experiment_root / self.annotation_dir / (self.position_name + '.pickle')
 
     def load_annotations(self):
         try:

--- a/elegant/load_data.py
+++ b/elegant/load_data.py
@@ -173,29 +173,29 @@ def write_metadata(metadata, experiment_root):
     metadata_file = pathlib.Path(experiment_root) / 'experiment_metadata.json'
     datafile.json_encode_atomic_legible_to_file(metadata, metadata_file)
 
-def read_annotations(experiment_root):
+def read_annotations(experiment_root, annotation_subdir='annotations'):
     """Read annotation data from an experiment directory.
-
     Parameters:
         experiment_root: the path to an experimental directory.
-
+        annotation_subdir: subdirectory under experient_root containing
+            annotations of interest (pathlib.Path or string)
     Returns: an ordered dictionary mapping position names to annotations,
         where each annotation is a (position_annotations, timepoint_annotations)
         pair. In this, position_annotations is a dict of "global" per-position
         annotation information, while timepoint_annotations is an ordered dict
         mapping timepoint names to annotation dictionaries (which themselves map
         strings to annotation data).
-
     Example:
         positions = read_annotations('my_experiment')
         position_annotations, timepoint_annotations = positions['009']
         life_stage = timepoint_annotations['2017-04-23t0122']['stage']
     """
     experiment_root = pathlib.Path(experiment_root)
+    annotation_root = experiment_root / annotation_subdir
     positions = collections.OrderedDict()
-    for annotation_file in sorted(experiment_root.glob('annotations/*.pickle')):
+    for annotation_file in sorted(annotation_root.glob('*.pickle')):
         worm_name = annotation_file.stem
-        positions[worm_name] = read_annotation_file(annotation_file)
+        positions[worm_name] = load_data.read_annotation_file(annotation_file)
     return positions
 
 def read_annotation_file(annotation_file):

--- a/elegant/load_data.py
+++ b/elegant/load_data.py
@@ -222,11 +222,11 @@ def read_annotation_file(annotation_file):
     timepoint_annotations = collections.OrderedDict(sorted(timepoint_annotations.items()))
     return position_annotations, timepoint_annotations
 
-def write_annotations(experiment_root, positions):
+def write_annotations(experiment_root, positions, annotation_subdir='annotations'):
     """Converse of read_annotations(): write a set of annotation files back,
     from a positions dictionary like that returned by read_annotations().
     """
-    annotation_dir = pathlib.Path(experiment_root) / 'annotations'
+    annotation_dir = pathlib.Path(experiment_root) / annotation_subdir
     for position_name, (position_annotations, timepoint_annotations) in positions.items():
         annotation_file = annotation_dir / f'{position_name}.pickle'
         write_annotation_file(annotation_file, position_annotations, timepoint_annotations)

--- a/elegant/load_data.py
+++ b/elegant/load_data.py
@@ -173,11 +173,11 @@ def write_metadata(metadata, experiment_root):
     metadata_file = pathlib.Path(experiment_root) / 'experiment_metadata.json'
     datafile.json_encode_atomic_legible_to_file(metadata, metadata_file)
 
-def read_annotations(experiment_root, annotation_subdir='annotations'):
+def read_annotations(experiment_root, annotation_dir='annotations'):
     """Read annotation data from an experiment directory.
     Parameters:
         experiment_root: the path to an experimental directory.
-        annotation_subdir: subdirectory under experient_root containing
+        annotation_dir: subdirectory under experient_root containing
             annotations of interest (pathlib.Path or string)
     Returns: an ordered dictionary mapping position names to annotations,
         where each annotation is a (position_annotations, timepoint_annotations)
@@ -191,11 +191,11 @@ def read_annotations(experiment_root, annotation_subdir='annotations'):
         life_stage = timepoint_annotations['2017-04-23t0122']['stage']
     """
     experiment_root = pathlib.Path(experiment_root)
-    annotation_root = experiment_root / annotation_subdir
+    annotation_root = experiment_root / annotation_dir
     positions = collections.OrderedDict()
     for annotation_file in sorted(annotation_root.glob('*.pickle')):
         worm_name = annotation_file.stem
-        positions[worm_name] = load_data.read_annotation_file(annotation_file)
+        positions[worm_name] = read_annotation_file(annotation_file)
     return positions
 
 def read_annotation_file(annotation_file):
@@ -222,13 +222,13 @@ def read_annotation_file(annotation_file):
     timepoint_annotations = collections.OrderedDict(sorted(timepoint_annotations.items()))
     return position_annotations, timepoint_annotations
 
-def write_annotations(experiment_root, positions, annotation_subdir='annotations'):
+def write_annotations(experiment_root, positions, annotation_dir='annotations'):
     """Converse of read_annotations(): write a set of annotation files back,
     from a positions dictionary like that returned by read_annotations().
     """
-    annotation_dir = pathlib.Path(experiment_root) / annotation_subdir
+    annotation_root = pathlib.Path(experiment_root) / annotation_dir
     for position_name, (position_annotations, timepoint_annotations) in positions.items():
-        annotation_file = annotation_dir / f'{position_name}.pickle'
+        annotation_file = annotation_root / f'{position_name}.pickle'
         write_annotation_file(annotation_file, position_annotations, timepoint_annotations)
 
 def write_annotation_file(annotation_file, position_annotations, timepoint_annotations):


### PR DESCRIPTION
This feature allows a user to load+save annotations from a location that is different that the canonical experiment_root/'annotations' directory. This is useful when multiple individuals are annotating an experiment (e.g. for testing the quality/reproducibility of annotations).