### PR TITLE
Proposed bugfix for _get_pose to handle null masks

### DIFF
--- a/elegant/segment_images.py
+++ b/elegant/segment_images.py
@@ -192,7 +192,7 @@ def find_lawn_in_image(image, optocoupler, return_model=False):
 
 def _get_pose(mask, timepoint_annotations, timepoint_name, width_estimator):
     center_tck, width_tck = worm_spline.pose_from_mask(mask)
-    if width_estimator is not None:
+    if width_estimator is not None and center_tck is not None:
         current_annotation = timepoint_annotations[timepoint_name]
         age = None
         if 'age' in current_annotation:

--- a/elegant/segment_images.py
+++ b/elegant/segment_images.py
@@ -192,7 +192,7 @@ def find_lawn_in_image(image, optocoupler, return_model=False):
 
 def _get_pose(mask, timepoint_annotations, timepoint_name, width_estimator):
     center_tck, width_tck = worm_spline.pose_from_mask(mask)
-    if width_estimator is not None and center_tck is not None:
+    if width_estimator is not None and width_tck is not None:
         current_annotation = timepoint_annotations[timepoint_name]
         age = None
         if 'age' in current_annotation:


### PR DESCRIPTION
In the latest commit, segment_image.get_pose attempts to generate a pose from mask file, then perform some smoothing on the derived width_tck. If the mask is empty, this results in an error in width_estimator.pca_smooth_widths. This bugfix adds a conditional to handle this exception case.