### PR TITLE
Combined bug report + proposed bugfix for handling aberrant masks

### DIFF
--- a/elegant/worm_spline.py
+++ b/elegant/worm_spline.py
@@ -37,7 +37,7 @@ def pose_from_mask(mask, smoothing=2):
     sx, sy = slices[0]
     cropped = mask[sx, sy]
     centerline, widths = _get_centerline(cropped)
-    if centerline.size < 10:
+    if len(centerline) < 10:
         return None, None
     center_tck, width_tck = _get_splines(centerline, widths)
     # adjust x, y coords to account for the cropping

--- a/elegant/worm_spline.py
+++ b/elegant/worm_spline.py
@@ -37,6 +37,8 @@ def pose_from_mask(mask, smoothing=2):
     sx, sy = slices[0]
     cropped = mask[sx, sy]
     centerline, widths = _get_centerline(cropped)
+    if centerline.size == 0:
+        return None, None
     center_tck, width_tck = _get_splines(centerline, widths)
     # adjust x, y coords to account for the cropping
     c = center_tck[1]

--- a/elegant/worm_spline.py
+++ b/elegant/worm_spline.py
@@ -37,7 +37,7 @@ def pose_from_mask(mask, smoothing=2):
     sx, sy = slices[0]
     cropped = mask[sx, sy]
     centerline, widths = _get_centerline(cropped)
-    if centerline.size == 0:
+    if centerline.size < 10:
         return None, None
     center_tck, width_tck = _get_splines(centerline, widths)
     # adjust x, y coords to account for the cropping


### PR DESCRIPTION
The mask file  '/mnt/9karray/Sinha_Drew/20181130_spe-9_A/06/2018-12-07t1937 bf_7.png' is a aberrant mask resulting from segmentation on a partially out-of-focus image; the largest object in this image is smaller than 25 px (see below). Running worm_spline.pose_from_mask on this mask yields the following error:

In [6]: worm_spline.pose_from_mask(mask)
---------------------------------------------------------------------------
AxisError                                 Traceback (most recent call last)
<ipython-input-6-5796b4a7b3a3> in <module>()
----> 1 worm_spline.pose_from_mask(mask)

/media/Data/Work/ZPLab/Analysis/Scripts/src/package/elegant/worm_spline.py in pose_from_mask(mask, smoothing)
     38     cropped = mask[sx, sy]
     39     centerline, widths = _get_centerline(cropped)
---> 40     **center_tck, width_tck = _get_splines(centerline, widths)**
     41     # adjust x, y coords to account for the cropping
     42     c = center_tck[1]

/media/Data/Work/ZPLab/Analysis/Scripts/src/package/elegant/worm_spline.py in _get_splines(centerline, widths)
    105 
    106     # create splines for the first points and extrapolate to presumptive mask edge
--> 107     begin_tck = interpolate.fit_spline(centerline[:10], smoothing=4, order=1)
    108     dist_to_edge = widths[0]
    109     t = numpy.linspace(-dist_to_edge, 0, int(round(dist_to_edge)), endpoint=False)

~/miniconda/envs/zplab_stable/lib/python3.6/site-packages/zplib/curve/interpolate.py in fit_spline(points, smoothing, order, force_endpoints)
     72     # doesn't accelerate/decelerate, so points along the curve in the x,y plane
     73     # don't "bunch up" with evenly-spaced parameter values.)
---> 74     distances = geometry.cumulative_distances(points, unit=False)
     75     if numpy.any(numpy.isclose(distances[1:] - distances[:-1], 0)):
     76         raise ValueError("Repeated input points are not allowed.")

~/miniconda/envs/zplab_stable/lib/python3.6/site-packages/zplib/curve/geometry.py in cumulative_distances(points, unit)
      9           if False, return actual arc lengths."""
     10     points = numpy.asarray(points)
---> 11     distances = numpy.concatenate([[0], numpy.add.accumulate(numpy.sqrt(((points[:-1] - points[1:])**2).sum(axis=1)))])
     12     if unit:
     13         distances /= distances[-1]

~/miniconda/envs/zplab_stable/lib/python3.6/site-packages/numpy/core/_methods.py in _sum(a, axis, dtype, out, keepdims)
     30 
     31 def _sum(a, axis=None, dtype=None, out=None, keepdims=False):
---> 32     return umr_sum(a, axis, dtype, out, keepdims)
     33 
     34 def _prod(a, axis=None, dtype=None, out=None, keepdims=False):

AxisError: axis 1 is out of bounds for array of dimension 1


On further investigation, the centerline passed back from _get_centerline in worm_spline:39 is empty. On loading the mask and cropping according to worm_spline:38, the cropped mask for the largest object is the matrix:

array([[ True,  True, False, False],
       [ True,  True, False, False],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True]])

The subsequent skeleton for this cropped subimage is:

array([[ True,  True, False, False],
       [ True, False, False, False],
       [ True, False, False, False],
       [ True, False, False, False],
       [ True, False, False, False],
       [False,  True,  True,  True]])

yielding only one endpoint after application of the hit-or-miss transform:

In [27]: endpoints
Out[27]:
array([[False, False, False, False],
       [False, False, False, False],
       [False, False, False, False],
       [False, False, False, False],
       [False, False, False, False],
       [False, False, False,  True]])

In [28]: ep_indices
Out[28]: array([[5, 3]])

The proposed bugfix sets up up a temporary fix to catch the null centerline in pose_from_mask. I'm not sure if this is an error condition that makes sense to address (I've only gotten this error on small, pathological masks as in this scenario in which segmentation misses most or all of the worm entirely).
