### PR TITLE
Workflow enhancements

### DIFF
--- a/elegant/process_experiment.py
+++ b/elegant/process_experiment.py
@@ -65,7 +65,7 @@ def compress_main(argv=None):
 
 def segment_experiment(experiment_root, model, channels='bf', use_gpu=True, overwrite_existing=False,
     timepoint_filter=None, mask_root=None):
-    """Segment all 'bf' image files from an experiment directory and annotate poses.
+    """Segment image files from an experiment directory and annotate poses.
 
     For more complex needs, use segment_images.segment_positions. This function
     is largely a simple example of its usage.
@@ -89,7 +89,12 @@ def segment_experiment(experiment_root, model, channels='bf', use_gpu=True, over
 
     experiment_root = pathlib.Path(experiment_root)
     positions = load_data.scan_experiment_dir(experiment_root, channels=channels, timepoint_filter=timepoint_filter)
-    segment_images.segment_positions(positions, model, mask_root, use_gpu, overwrite_existing)
+    if positions:
+        process = segment_images.segment_positions(positions, model, mask_root, use_gpu, overwrite_existing)
+        if process.stderr:
+            print(f'Errors during segmentation: {process.stderr}')
+    else:
+        print('No images found to segment.')
     annotations = load_data.read_annotations(experiment_root)
     metadata = load_data.read_metadata(experiment_root)
     age_factor = metadata.get('age_factor', 1) # see if there is an "age factor" stashed in the metadata...

--- a/elegant/process_experiment.py
+++ b/elegant/process_experiment.py
@@ -64,7 +64,7 @@ def compress_main(argv=None):
     compress_pngs(**args.__dict__)
 
 def segment_experiment(experiment_root, model, channels='bf', use_gpu=True, overwrite_existing=False,
-    timepoint_filter=None, mask_root=None):
+    timepoint_filter=None, mask_dir=None):
     """Segment image files from an experiment directory and annotate poses.
 
     For more complex needs, use segment_images.segment_positions. This function
@@ -82,12 +82,13 @@ def segment_experiment(experiment_root, model, channels='bf', use_gpu=True, over
             mask files, nor will existing annotations be modified even if new
             mask files are generated for a timepoint.
         timepoint_filter - filter for scan_experiment_dir specifying timepoints to segment
-        mask_root - root directory for masks that will be used to updating annotations
+        mask_dir - subdirectory (under experiment_root) for masks that will be used to update annotations
     """
-    if mask_root is None:
-        mask_root = experiment_root / 'derived_data' / 'mask'
-
+    if mask_dir is None:
+        mask_dir = 'derived_data' / 'mask'
     experiment_root = pathlib.Path(experiment_root)
+    mask_root = experiment_root / mask_dir
+
     positions = load_data.scan_experiment_dir(experiment_root, channels=channels, timepoint_filter=timepoint_filter)
     if positions:
         process = segment_images.segment_positions(positions, model, mask_root, use_gpu, overwrite_existing)

--- a/elegant/process_experiment.py
+++ b/elegant/process_experiment.py
@@ -93,6 +93,9 @@ def segment_experiment(experiment_root, model, channels='bf', use_gpu=True, over
         process = segment_images.segment_positions(positions, model, mask_root, use_gpu, overwrite_existing)
         if process.stderr:
             print(f'Errors during segmentation: {process.stderr}')
+        with (mask_root / 'notes.txt').open('a+') as notes_file:
+            notes_file.write(
+                f'{datetime.datetime.today().strftime("%Y-%m-%dt%H%M")} These masks were segmented with model {model}\n')
     else:
         print('No images found to segment.')
     annotations = load_data.read_annotations(experiment_root)

--- a/elegant/process_experiment.py
+++ b/elegant/process_experiment.py
@@ -63,7 +63,8 @@ def compress_main(argv=None):
     args = parser.parse_args(argv)
     compress_pngs(**args.__dict__)
 
-def segment_experiment(experiment_root, model, channels='bf', use_gpu=True, overwrite_existing=False):
+def segment_experiment(experiment_root, model, channels='bf', use_gpu=True, overwrite_existing=False,
+    timepoint_filter=None, mask_root=None):
     """Segment all 'bf' image files from an experiment directory and annotate poses.
 
     For more complex needs, use segment_images.segment_positions. This function
@@ -80,10 +81,14 @@ def segment_experiment(experiment_root, model, channels='bf', use_gpu=True, over
         overwrite_existing: if False, the segmenter will not be run on existing
             mask files, nor will existing annotations be modified even if new
             mask files are generated for a timepoint.
+        timepoint_filter - filter for scan_experiment_dir specifying timepoints to segment
+        mask_root - root directory for masks that will be used to updating annotations
     """
+    if mask_root is None:
+        mask_root = experiment_root / 'derived_data' / 'mask'
+
     experiment_root = pathlib.Path(experiment_root)
-    positions = load_data.scan_experiment_dir(experiment_root, channels=channels)
-    mask_root = experiment_root / 'derived_data' / 'mask'
+    positions = load_data.scan_experiment_dir(experiment_root, channels=channels, timepoint_filter=timepoint_filter)
     segment_images.segment_positions(positions, model, mask_root, use_gpu, overwrite_existing)
     annotations = load_data.read_annotations(experiment_root)
     metadata = load_data.read_metadata(experiment_root)

--- a/elegant/segment_images.py
+++ b/elegant/segment_images.py
@@ -122,6 +122,8 @@ def annotate_poses_from_masks(positions, mask_root, annotations, overwrite_exist
             the worm hatched at the first timepoint taken.
     """
     for position_name, timepoint_name, image_path in load_data.flatten_positions(positions):
+        print(f'Annotating poses for position {position_name}')
+
         mask_path = mask_root / position_name / (image_path.stem + '.png')
         position_annotations, timepoint_annotations = annotations.setdefault(position_name, ({}, {}))
         current_annotation = timepoint_annotations.setdefault(timepoint_name, {})


### PR DESCRIPTION
This pull request (1) adds some verbosity to aid users keep track of progress during data processing as well as during segmentation errors, and (2) exposes some additional default options for segmenting experiments. The latter incrementally builds upon the default, simplistic workflow specified for segment_experiment, but handles some obvious user cases (e.g. individual wants to segment only adult or larval images).