### PR TITLE
Stage propagation now happens when updating annotations [combined report + proposed fix]

### DIFF
--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -38,7 +38,6 @@ def propagate_stages(experiment_root,verbose=False):
     annotations = load_data.read_annotations(experiment_root)
     for position_name, (position_annotations, timepoint_annotations) in annotations.items():
         running_stage = None
-        changed = []
         encountered_stages = []
 
         for timepoint,timepoint_info in timepoint_annotations.items():


### PR DESCRIPTION
This bug report + fix addresses a problem where annotation and timepoint acquisition independently modifying annotations leads to a race condition.

While a user is performing manually annotations, timepoint acquisition on the scope also modifies experiment annotations separately (i.e. rpc-scope:base_handler:146). If a user has already annotated a life stage for a given worm during a round of annotations, acquiring an additional timepoint results in a dangling timepoint annotation that has no stage annotation. In theory, this won't cause a problem if the worm is reloaded; however, this assumption may not always be satisfied (particularly in the scenario that a worm is counted as dead and then filtered out during subsequent rounds of annotation). The dangling non-annotated timepoint may cause subsequent errors (i.e. when an elegant or user-defined function goes looking for stage annotations assuming that they already exist for each timepoint).

For the existing workflow, the primary annotation that is affected by this race condition is the stage annotation. The proposed fix introduces a function, propagate_stages, to fill in dangling timepoints when a user runs update_annotations. The logic of this function is essentially the same as the stage propagation that occurs in the experiment_annotator. It may also be useful to add this to rpc-scope's base_handler (possibly instead of its addition in update_annotations) as a way to guard against this race condition more generally.