### PR TITLE
Appending to annotations without collisions

### DIFF
--- a/elegant/load_data.py
+++ b/elegant/load_data.py
@@ -4,6 +4,8 @@ import collections
 import pathlib
 import pickle
 import json
+import time
+import fcntl
 
 from zplib import datafile
 

--- a/elegant/load_data.py
+++ b/elegant/load_data.py
@@ -269,16 +269,15 @@ def append_annotation_file(annotation_file, position_diff, timepoint_diff):
 
     Parameters:
         annotation_file: path to an existing annotation file
-        position_diff: diff as a dict of "global" per-position annotations to apply to current annotations;
-        timepoint_annotations: diff as an ordered dict mapping timepoint names to
-            annotation dictionaries (which map strings to annotation data)
+        position_diff: diff as a dict of "global" per-position annotations to apply to current annotations
+        timepoint_diff: diff as an ordered dict mapping timepoint names to annotation dictionaries (which map strings to annotation data)
     """
     annotation_file = pathlib.Path(annotation_file)
     annotation_file.parent.mkdir(exist_ok=True)
     while True:
         try:
             latest_annotations = read_annotation_file(annotation_file)
-            merge_annotations(latest_annotations, (position_annotations, timepoint_annotations))
+            merge_annotations(latest_annotations, (position_diff, timepoint_diff))
             with annotation_file.open('wb') as af:
                 fcntl.flock(af, fcntl.LOCK_EX)
                 pickle.dump((dict(latest_annotations[0]), dict(latest_annotations[1])), af)

--- a/elegant/load_data.py
+++ b/elegant/load_data.py
@@ -328,7 +328,7 @@ def diff_annotations(ref_annotations, new_annotations):
         for timepoint_name in new_timepoint_annotations:
             ta_diff[timepoint_name] = {}
             for ta_diff in new_timepoint_annotations[timepoint_name]:
-                field_in_ref = ta_field not in ref_timepoint_annotations[timepoint_name]
+                field_in_ref = ta_field in ref_timepoint_annotations[timepoint_name]
                 if not field_in_ref or new_timepoint_annotations[timepoint_name][ta_field] != ref_timepoint_annotations[timepoint_name][ta_field]:
                     ta_diff[timepoint_name][ta_field] = new_timepoint_annotations[timepoint_name][ta_field]
     return diff


### PR DESCRIPTION
A point brought up in the previous discussion about race conditions was that multiple processes cannot modify/append annotations simultaneously. Consequences of this include (1) that only one set of modifications can be performed on a set of annotations at a time, and (2) a given task (e.g. calculating poses) cannot be parallelized. This latter point has come to attention with the fact that recent experiments with multipass acquisition data require a significant amount of time to calculate poses (>~16-20 hr):

In [1]: experiment_dir = '/mnt/9karray/Sinha_Drew/20190111_spe-9_B' # ... next command errored out

In [3]: %run segmentation_pipeline.py $experiment_dir # Segment and annotate all 'adult' stage poses
Image channels to be segmented: ['bf', 'bf_1', 'bf_2', 'bf_3', 'bf_4', 'bf_5', 'bf_6', 'bf_7']
scanning done after 69.39152073860168 s
segmenting done after 399.05126547813416 s
**annotation done after 54436.36029171944 s**

(Note: (1) this was annotation of a portion of the whole dataset, and (2) back of the envelope calculations put pose calculation on the order of several seconds, suggesting that this isn't necessarily an optimization issue with pose calculation)

The proposed feature adds some infrastructure that would allow multiple tasks to be performed on a set of annotations at once. First, a function for "diff'ing" experiment annotations (diff_annotations) allows recognition of fields that change after a set of modifcations. Second, a set of functions mirroring the current read/write infrastructure uses diff_annotations and merge_annotations to safely append to a set of annotations. In particular, this appending functionality uses file locking to capture the latest set of annotations and rewrite the annotation file without fear of collision.