### PR TITLE
worm_data.calculate_ages_and_spans does not calculate adult_age on worms that are still alive

### DIFF
--- a/elegant/worm_data.py
+++ b/elegant/worm_data.py
@@ -364,17 +364,18 @@ class Worm(object):
         spans = transition_times[1:] - transition_times[:-1]
         for stage, span in zip(stages[:-1], spans):
             setattr(self, f'{stage}span', span)
-        if stages[-1] != 'dead':
-            raise ValueError('No timepoint with "dead" label is present; cannot calculate lifespan.')
-        death_time = transition_times[-1]
-        self.td.ghost_age = hours - death_time
-        self.lifespan = death_time - hatch_time
         try:
             adult_i = list(stages).index('adult')
         except ValueError:
             raise ValueError('No timepoint with "adult" label is present; cannot calculate adult_age.')
         adult_time = transition_times[adult_i]
         self.td.adult_age = hours - adult_time
+        if stages[-1] != 'dead':
+            raise ValueError('No timepoint with "dead" label is present; cannot calculate lifespan.')
+        death_time = transition_times[-1]
+        self.td.ghost_age = hours - death_time
+        self.lifespan = death_time - hatch_time
+
 
     def __repr__(self):
         return f'Worm("{self.name}")'


### PR DESCRIPTION
This is a combined bug report/proposed fix. 

When attempting to generate worm_data summary/timecourse files for an experiment with an animal that's still alive (e.g. 9karray/Sinha_Drew/20190125_spe-9_Ctrl), the adult_age for the live animal is all numpy.nans. In calculate_ages_and_spans, the Worm object attempts to calculate ghost_age, but, when it cannot find a 'dead' timepoint, throws a ValueError. Because of this, the subsequent codeblock that calculates adult_age does not run and Worm.td.adult_age is not populated. This causes obvious problems for any subsequent analysis utilizing adult_age.

As in the short-term fix proposed here, it seems reasonable to switch the order of the code blocks so that adult_age is calculated, if possible. In my case, one may want to generate preliminary data for an experiment before it's done. However, it is unclear whether the policy of rethrowing the ValueError when no 'adult' stage is annotated is the right one. If an individual fails to annotate death but not onset of adulthood, should lifespan still be calculated? This seems to be the logic as it is now (coupled with its call in the code block at read_worms:113).

