### PR TITLE
Fix lawn measurements

### DIFF
--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -528,10 +528,12 @@ class LawnMeasurements:
         # Remove the animal from the lawn if possible.
         center_tck, width_tck = annotations.get('pose', (None, None))
         if center_tck is not None:
-            lawn_mask &= worm_spline.lab_frame_mask(center_tck, width_tck, timepoint_image.shape).astype('bool')
+            animal_mask = worm_spline.lab_frame_mask(center_tck, width_tck, timepoint_image.shape).astype('bool')
+        else:
+            animal_mask = numpy.zeros_like(lawn_mask).astype('bool') # Doesn't mask out anything
 
-        measures['summed_lawn_intensity'] = numpy.sum(rescaled_image[lawn_mask])
-        measures['median_lawn_intensity'] = numpy.median(rescaled_image[lawn_mask])
+        measures['summed_lawn_intensity'] = numpy.sum(rescaled_image[lawn_mask & ~animal_mask])
+        measures['median_lawn_intensity'] = numpy.median(rescaled_image[lawn_mask & ~animal_mask])
         measures['background_intensity'] = numpy.median(rescaled_image[~lawn_mask & vignette_mask])
 
         return [measures[feature_name] for feature_name in self.feature_names]

--- a/elegant/process_data.py
+++ b/elegant/process_data.py
@@ -528,12 +528,12 @@ class LawnMeasurements:
         # Remove the animal from the lawn if possible.
         center_tck, width_tck = annotations.get('pose', (None, None))
         if center_tck is not None:
-            animal_mask = worm_spline.lab_frame_mask(center_tck, width_tck, timepoint_image.shape).astype('bool')
+            worm_mask = worm_spline.lab_frame_mask(center_tck, width_tck, timepoint_image.shape).astype('bool')
         else:
-            animal_mask = numpy.zeros_like(lawn_mask).astype('bool') # Doesn't mask out anything
+            worm_mask = numpy.zeros_like(lawn_mask).astype('bool') # Doesn't mask out anything
 
-        measures['summed_lawn_intensity'] = numpy.sum(rescaled_image[lawn_mask & ~animal_mask])
-        measures['median_lawn_intensity'] = numpy.median(rescaled_image[lawn_mask & ~animal_mask])
+        measures['summed_lawn_intensity'] = numpy.sum(rescaled_image[lawn_mask & ~worm_mask])
+        measures['median_lawn_intensity'] = numpy.median(rescaled_image[lawn_mask & ~worm_mask])
         measures['background_intensity'] = numpy.median(rescaled_image[~lawn_mask & vignette_mask])
 
         return [measures[feature_name] for feature_name in self.feature_names]


### PR DESCRIPTION
This bugfix fixes incorrect behavior of lawn measurement code in process_data.LawnMeasurements.measure:531-537.

In process_data:531, the lawn_mask is updated to be the intersection of the lawn mask and the worm mask in the lab frame. This is incorrect. The intended logic is to limit the area for measurement of lawn intensity to the lawn mask excluding the worm mask. That logic is fixed in this bugfix. 

Moreover, the previous logic of updating the lawn mask directly to exclude the worm mask also makes the estimate of background intensity slightly incorrect (the area over which the calculation is made will also include the area where the worm is). In this bugfix, the animal mask kept separate to avoid this issue.